### PR TITLE
Add function to create mutt tmux session

### DIFF
--- a/files/.tmux.conf.local
+++ b/files/.tmux.conf.local
@@ -1,3 +1,5 @@
+# vim: ft=tmux
+
 bind J send-keys C-z "fg; jay done" Enter
 bind R source-file ~/.tmux.conf \; display "Reloaded ~/.tmux.conf"
 bind -T copy-mode-vi Enter send-keys -X copy-pipe 'reattach-to-user-namespace pbcopy' \; send -X clear-selection

--- a/files/.zshrc.local
+++ b/files/.zshrc.local
@@ -2,6 +2,16 @@ c() {
   cd "$HOME/code/$1"
 }
 
+fido() {
+  if ! $(tmux has-session -t mutt &>/dev/null); then
+    cd ~
+    tmux new-session -d -s mutt
+    tmux source-file ~/code/dotfiles/tmux/mutt.conf
+  fi
+
+  tmux attach-session -t mutt
+}
+
 open_rails_console() {
   if [ -e hokusai/$1.yml ]; then
     echo "hokusai $1 run 'bundle exec rails c' --tty"

--- a/tmux/mutt.conf
+++ b/tmux/mutt.conf
@@ -1,0 +1,9 @@
+# vim: ft=tmux
+
+split-window -h -t mutt
+split-window -h -t mutt
+
+send-keys -t mutt.1 'mg' Enter
+send-keys -t mutt.2 'mw' Enter
+
+select-layout -t mutt main-vertical


### PR DESCRIPTION
What I'm doing here is creating a shell function to create or attach to a `mutt` session that's configured just how I like it. One thing that remains a mystery to me here is the difficulty I had using the `tmux source-file` command. What I wanted to be able to do was something more like this:

```
tmux new-session -d -s mutt; source-file path
```

But I couldn't get both commands to work in the same line. I'm confused about this because `hr mux` is able to do it so I guess I'm doing something wrong, but decided to move on before I could figure it out.

Closes #31