### PR TITLE
Add func to create compare link

### DIFF
--- a/rcm/zsh/aliases
+++ b/rcm/zsh/aliases
@@ -15,6 +15,7 @@ alias gco='git checkout'
 alias gd="git diff -- ':!package-lock.json' ':!yarn.lock'"
 alias gdc="git diff --cached -- ':!package-lock.json' ':!yarn.lock'"
 alias git=hub
+alias ghc=github_compare
 alias gp='git push'
 alias gpr='git pull --rebase'
 alias gr='git rebase'

--- a/rcm/zsh/funcs
+++ b/rcm/zsh/funcs
@@ -5,6 +5,17 @@ c() {
 }
 compctl -/ -S '' -W "$HOME/code" c
 
+github_compare() {
+  current_branch=$(git symbolic-ref --quiet --short HEAD)
+
+  if [ "$current_branch" == "master" ]; then
+    echo "must be on feature branch"
+    return 1
+  fi
+
+  hub compare jonallured:$current_branch
+}
+
 ddd() {
   rspec --dry-run --order defined --format documentation $1
 }


### PR DESCRIPTION
Useful for creating PRs, what this actually does is create and open a link to a GitHub compare page using the current branch. If you're on master it'll bail.

Closes #94 

/cc @pepopowitz