### PR TITLE
Add script to nuke node modules folders

### DIFF
--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -16,6 +16,14 @@ github_compare() {
   hub compare jonallured:$current_branch
 }
 
+nuke_modules() {
+  node_modules=$(find $HOME/code -name node_modules -type d -maxdepth 3)
+  printf '%s\n' "${node_modules[@]}"
+  total=$(echo $node_modules | xargs du -s -c -h | tail -n 1 | cut -f 1)
+  echo $node_modules | xargs rm -rf $node_modules
+  echo "$total cleaned up"
+}
+
 ddd() {
   rspec --dry-run --order defined --format documentation $1
 }


### PR DESCRIPTION
I was inspired by @zephraph and his clean up script but wanted to try a less careful approach! 😝 

All I'm doing here is finding `node_modules` folders in my `code` folder that are at depth 3, counting up their size and then removing them.

Here's the result for today:

```
jon@magneto:~/code/dotfiles(clean-script*)% nuke_modules
/Users/jon/code/monolithium/node_modules
/Users/jon/code/perf-audits/node_modules
/Users/jon/code/refraction/node_modules
/Users/jon/code/reaction/node_modules
/Users/jon/code/metaphysics/node_modules
/Users/jon/code/test/node_modules
/Users/jon/code/pulse/node_modules
/Users/jon/code/noteblock/node_modules
/Users/jon/code/graham/node_modules
/Users/jon/code/volt/node_modules
/Users/jon/code/miasma/node_modules
/Users/jon/code/jay/node_modules
/Users/jon/code/danger-plugin-spellcheck/node_modules
/Users/jon/code/rosalind/node_modules
/Users/jon/code/force/node_modules
/Users/jon/code/currents/node_modules
/Users/jon/code/peril-settings/node_modules
/Users/jon/code/forty-web/node_modules
/Users/jon/code/palette/node_modules
5.0G cleaned up
```

So then I'll add this to my sharpen script and run it weekly.

Closes #107 