### PR TITLE
Define global git hooks

### DIFF
--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -29,6 +29,7 @@
 [core]
 	editor = vim
 	excludesfile = ~/.global_ignore
+	hooksPath = ~/.git-hooks/shims
 	ignorecase = false
 	whitespace = warn
 [diff]

--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -29,6 +29,7 @@
 [core]
 	editor = vim
 	excludesfile = ~/.global_ignore
+	ignorecase = false
 	whitespace = warn
 [diff]
 	algorithm = patience


### PR DESCRIPTION
What I'm working on here is adding a global hooks path so that I can better control my git hooks. What this does in practice is that any of my projects with local git hooks will have those hooks skipped. For instance, the Volt hooks for running prettier, etc are skipped.

But then, I've also defined a hook to check for `pear` being setup and it will add the trailer to the commit message when it finds one. I'm going to roll with this for a while and see if I like it.