### PR TITLE
Simplify the replace function

### DIFF
--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -99,15 +99,7 @@ replace() {
   replacement="$1"
   shift
 
-  matches=$(ag -l --nocolor "$target" "$@")
-
-  pid="$$"
-  scratch="/tmp/replace-scratch-file-$pid.txt"
-
-  IFS=$'\n'
-  for match in $matches; do
-    sed "s/$target/$replacement/g" "$match" > "$scratch" && mv "$scratch" "$match"
-  done
+  ag -l --nocolor "$target" "$@" | xargs sed -i '' "s/$target/$replacement/g"
 }
 
 twiki() {


### PR DESCRIPTION
I was having lots of issues with the more complex version of this and found it easier to just pipe from ag to sed through xargs. This _does_ mean that I won't have backups when running this command, but I think that's ok. I noticed that usually when I use this function I'm in the context of a group of files under version control anyway, so they are backed up. Famous last words! 😝 