### PR TITLE
Add script to run sharpen commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ rcm/mutt/dracula
 rcm/mutt/tmp
 rcm/vim/plugs/*
 rcm/vim/undo/*
+replug.log

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ rcm/mutt/tmp
 rcm/vim/plugs/*
 rcm/vim/undo/*
 replug.log
+sharpen.log

--- a/rcm/zsh/aliases
+++ b/rcm/zsh/aliases
@@ -44,7 +44,6 @@ alias p='open_rails_console production'
 alias r="rake"
 alias randoemails="echo 'require \"csv\"; puts Season.current.player_emails.compact.sort.to_csv.chomp' | heroku run console --no-tty | tail -n 3 | head -n 1 | pbcopy"
 alias rd='rmdir'
-alias replug="vim -c ':PlugClean | :PlugInstall | :PlugUpdate | :PlugUpgrade | qa'"
 alias reset-authors='git commit --amend --reset-author -C HEAD'
 alias rmnm="rm -rf node_modules/"
 alias rr='cd ..; cd -; rvm current'

--- a/rcm/zsh/exports
+++ b/rcm/zsh/exports
@@ -13,6 +13,7 @@ export EDITOR='vim'
 export PSQL_EDITOR='vim -c"setf sql"'
 
 export DISABLE_SPRING=1
+export DOTHOME="/Users/jon/code/dotfiles"
 export LAB_NOTES_HOME="/Users/jon/code/lab_notes"
 export NVM_DIR="/Users/jon/.nvm"
 

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -136,3 +136,12 @@ replug() {
 twiki() {
   rake db:migrate && rake db:migrate:redo && rake db:test:prepare
 }
+
+sharp() {
+  sharpen_log="$DOTHOME/sharpen.log"
+  $DOTHOME/sharpen-script &> $sharpen_log
+  echo '+ nuke_modules' >> $sharpen_log
+  nuke_modules >> $sharpen_log
+  replug
+  jay done
+}

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -50,7 +50,7 @@ fido() {
   if ! $(tmux has-session -t mutt &>/dev/null); then
     cd ~
     tmux new-session -d -s mutt
-    tmux source-file ~/code/dotfiles/tmux/mutt.conf
+    tmux source-file $DOTHOME/tmux/mutt.conf
   fi
 
   tmux attach-session -t mutt
@@ -70,11 +70,11 @@ mux() {
   if ! $(tmux has-session -t $name &>/dev/null); then
     tmux new-session -d -s $name
 
-    conf=$HOME/code/dotfiles/tmux/$name.mux
+    conf=$DOTHOME/tmux/$name.mux
     if [ -f $conf ]; then
       tmux source-file $conf
     else
-      tmux source-file $HOME/code/dotfiles/tmux/default.mux
+      tmux source-file $DOTHOME/tmux/default.mux
     fi
   fi
 

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -102,6 +102,10 @@ replace() {
   ag -l --nocolor "$target" "$@" | xargs sed -i '' "s/$target/$replacement/g"
 }
 
+replug() {
+  vim -c ':PlugClean | :PlugInstall | :PlugUpdate | :PlugUpgrade | qa'
+}
+
 twiki() {
   rake db:migrate && rake db:migrate:redo && rake db:test:prepare
 }

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -103,7 +103,34 @@ replace() {
 }
 
 replug() {
-  vim -c ':PlugClean | :PlugInstall | :PlugUpdate | :PlugUpgrade | qa'
+  cd $DOTHOME
+
+  replug_log="replug.log"
+
+  rm -f $replug_log
+
+  echo '+ PlugClean' >> $replug_log
+  vim -c ':PlugClean | :%y* | qa'
+  pbpaste >> $replug_log
+
+  echo '+ PlugInstall' >> $replug_log
+  vim -c ':PlugInstall | :%y* | qa'
+  pbpaste >> $replug_log
+
+  echo '+ PlugUpdate' >> $replug_log
+  vim -c ':PlugUpdate | :%y* | qa'
+  pbpaste >> $replug_log
+
+  echo '+ PlugDiff' >> $replug_log
+  vim -c ':PlugDiff | :%y* | qa'
+  pbpaste >> $replug_log
+
+  echo '+ PlugUpgrade' >> $replug_log
+  vim -c ':PlugUpgrade | qa'
+  git diff rcm/vim/autoload/plug.vim >> $replug_log
+
+  echo '+ replug done' >> $replug_log
+  cd - > /dev/null
 }
 
 twiki() {

--- a/sharpen-script
+++ b/sharpen-script
@@ -1,0 +1,14 @@
+# vim: ft=zsh
+
+set -x
+
+# this command will exit 1 if there are no updates so set e afterwards
+brew upgrade bat fzf git heroku hokusai hub macvim the_silver_searcher tmux yarn
+set -e
+
+asdf update
+asdf plugin-update --all
+asdf reshim
+
+gem update --system
+npm install --global npm


### PR DESCRIPTION
This PR adds a `sharp` command that will run through the routine-type commands of the sharpening process. It sends the output to a couple log files. Along the way I rewrote `replug` to be a little more fancy and include the diffing of plugins.

The next steps are to improve this script and then to also automate the adding of the comment to the issue.

For #118