### PR TITLE
Add command to clean up remotes

### DIFF
--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -4,6 +4,7 @@
 	aliases=!git config -l | grep '^alias' | cut -c 7- | sort
 	br = branch
 	cheddar = commit --amend -CHEAD
+	clean-remote = !"git remote | grep -v -e origin -e upstream | xargs -n1 git remote remove"
 	co = checkout
 	cp = cherry-pick
 	delete-merged-branches = !git branch --merged master | grep -v -e 'master' -e '\\*' | xargs -n 1 git nuke


### PR DESCRIPTION
I opted for a git alias here, but could have been something else. All I'm really doing is listing remotes, removing `origin` and `upstream` from the list and then removing each with `xargs`. I might end up wanting to update this sucker to also remove remotes like `heroku`, `staging` or `production` at some point, but really doesn't matter rn.

Closes #139