### PR TITLE
Nuke fewer node module directories

### DIFF
--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -32,7 +32,8 @@ github_compare() {
 }
 
 nuke_modules() {
-  node_modules=$(find $HOME/code -name node_modules -type d ! -path "*jay*" ! -path "*volt*" -maxdepth 3)
+  allow_list="jay|convection|forty-web|volt"
+  node_modules=$(find $HOME/code -name node_modules -type d -maxdepth 3 | egrep -v $allow_list)
   printf '%s\n' "${node_modules[@]}"
   total=$(echo $node_modules | xargs du -s -c -h | tail -n 1 | cut -f 1)
   echo $node_modules | xargs rm -rf


### PR DESCRIPTION
There are a few more directories that I'd like to exclude from nuking but adding ever more NOT PATH options to find seemed dumb so I tried a different approach. What I'm doing here is piping the output of find to egrep with an allow list. That means I can come into this file and add things to this pipe-delimited list and they'll be excluded from the nuking. Much easier.