### PR TITLE
Add func to update list of artsy repos

### DIFF
--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -172,3 +172,10 @@ sharp() {
   replug
   jay done
 }
+
+update_artsy_repos() {
+  cd ~/code/github_scripts
+  ruby artsy_repos.rb > ~/code/team-artsy-workflow-data/data/repos.yml
+  cd ~/code/team-artsy-workflow-data
+  git status
+}


### PR DESCRIPTION
This PR adds a func that wraps a sequence of commands to update the list of artsy repos that I like to run during a sharpen session. I used to just pull it out of my history, but that's silly - this is better.