### PR TITLE
Call out Xcode upgrading

### DIFF
--- a/.github/ISSUE_TEMPLATE/sharpen.md
+++ b/.github/ISSUE_TEMPLATE/sharpen.md
@@ -21,6 +21,7 @@
 * [ ] iTerm2
 * [ ] 1Password
 * [ ] Figma
+* [ ] [Xcode][]
 * [ ] do App Store.app updates
 * [ ] do System Updates
 
@@ -37,3 +38,5 @@
 * [ ] verify last backup on time machine
 * [ ] verify last backup on backblaze
 * [ ] reboot
+
+[Xcode]: https://developer.apple.com/download/more/


### PR DESCRIPTION
I went to go look at the current version of Xcode versus what I had installed and realized that I was behind! Then I loaded up Software Update and didn't see an update which reminded me that I had installed directly from the Apple Developers Downloads page.

So, I had a gap in my sharpen script and now this PR fixes it.