### PR TITLE
Add basic ssh config file

### DIFF
--- a/rcm/ssh/config
+++ b/rcm/ssh/config
@@ -1,0 +1,24 @@
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+
+Host domino
+  Hostname domino.jon.zone
+  User dev
+
+Host juggernaut
+  Hostname juggernaut.local
+  User jon
+
+Host mister-sinister
+  Hostname mister-sinister.local
+  User jon
+
+Host psylocke
+  Hostname psylocke.jon.zone
+  User dev
+
+Host sabretooth
+  Hostname sabretooth.local
+  User jon


### PR DESCRIPTION
I don't know why I never thought of this but adding this config file to my dotfiles makes it easier to share this around to my various machines. This will break on any machine that hasn't moved to Ed25519 so this will be a nudge to complete that migration wherever I haven't already.