### PR TITLE
Add git ensure main script

### DIFF
--- a/bin/git-ensure-main
+++ b/bin/git-ensure-main
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# for troubleshooting:
+# set -x
+
+git rev-parse --is-inside-work-tree > /dev/null
+
+current_branch=$(git branch --show-current)
+
+if [ $current_branch != "main" ]; then
+  echo "ERROR: must be on main branch"
+  exit 1
+fi

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -65,13 +65,7 @@ ddd() {
 }
 
 fetchup() {
-  current_branch=$(git branch --show-current)
-
-  if [ "$current_branch" != "main" ]; then
-    echo "must be on main branch"
-    return 1
-  fi
-
+  git ensure-main || return $?
   git fetch --all --quiet
 
   if git remote | grep upstream; then

--- a/rcm/zsh/path
+++ b/rcm/zsh/path
@@ -3,7 +3,7 @@
 export PATH=$PATH:$HOME/Library/Android/sdk/emulator
 export PATH=$PATH:$HOME/Library/Android/sdk/platform-tools
 export PATH=$PATH:$HOME/code/unicornleap/bin
-export PATH=$PATH:$HOME/code/git-ensure-main/bin
+export PATH=$PATH:$HOME/code/dotfiles/bin
 
 # remove duplicates
 typeset -aU path


### PR DESCRIPTION
Rather than having this script live completely outside my dotfiles repo, I'm establishing a pattern here where I put something like this in a bin folder. I think this is better because it makes dotfiles as a unit more self-contained but also now that I'm looking through my zsh functions, I think a bunch of them are really more like scripts. So yeah, more to come on this relocating of things.