### PR TITLE
Remove delta from git config

### DIFF
--- a/rcm/gitconfig
+++ b/rcm/gitconfig
@@ -21,7 +21,6 @@
 	excludesfile = ~/.global_ignore
 	hooksPath = ~/.git-hooks/shims
 	ignorecase = false
-	pager = delta
 	whitespace = warn
 [diff]
 	algorithm = patience
@@ -35,7 +34,6 @@
 	path = ~/.gitconfig.local
 [interactive]
 	singlekey = true
-	diffFilter = delta --color-only
 [github]
 	user = jonallured
 [merge]
@@ -70,15 +68,6 @@
 	whitespace = red reverse
 [init]
 	defaultBranch = main
-[delta]
-	features = line-numbers decorations
-	syntax-theme = Dracula
-	whitespace-error-style = 22 reverse
-[delta "decorations"]
-	commit-decoration-style = bold yellow box ul
-	file-style = bold yellow ul
-	file-decoration-style = none
-	hunk-header-decoration-style = cyan box ul
 [advice]
 	skippedCherryPicks = false
 [filter "lfs"]


### PR DESCRIPTION
While setting up my new laptop I hit errors because I did not have [delta](https://github.com/dandavison/delta) installed. I've used that tool for a long time but I wonder if I actually care? I'm going to try just going back to normal old diff output and see what I think. Easy enough to return to this if I feel that I want it back.