### PR TITLE
Make a bux command

### DIFF
--- a/rcm/tmux.conf
+++ b/rcm/tmux.conf
@@ -43,8 +43,8 @@ set-option -g status-left-length 30
 set-option -g status-right " #H | %I:%M %m/%d "
 set-option -g status-left " #S "
 set-option -g status-style fg=colour0,bg=colour2
-set-option -g pane-border-style fg=colour2
-set-option -g pane-active-border-style fg=colour7
+set-option -g pane-border-style fg=colour7
+set-option -g pane-active-border-style fg=colour2
 
 # Enable focus events for Vim autoread
 set-option -g focus-events on

--- a/rcm/tmux.conf
+++ b/rcm/tmux.conf
@@ -48,3 +48,6 @@ set-option -g pane-active-border-style fg=colour2
 
 # Enable focus events for Vim autoread
 set-option -g focus-events on
+
+# Select good layout
+bind-key g select-layout main-vertical

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -65,9 +65,9 @@ pathlist() {
 }
 
 replace() {
-  target="$1"
+  local target="$1"
   shift
-  replacement="$1"
+  local replacement="$1"
   shift
 
   ag -l --nocolor "$target" "$@" | xargs sed -i '' "s/$target/$replacement/g"
@@ -76,7 +76,7 @@ replace() {
 replug() {
   cd $DOTHOME
 
-  replug_log="replug.log"
+  local replug_log="replug.log"
 
   rm -f $replug_log
 
@@ -109,7 +109,7 @@ twiki() {
 }
 
 sharp() {
-  sharpen_log="$DOTHOME/sharpen.log"
+  local sharpen_log="$DOTHOME/sharpen.log"
   $DOTHOME/sharpen-script &> $sharpen_log
   replug
   jay done

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -25,25 +25,39 @@ l.() {
   ls -ld "${1:-$PWD}"/.[^.]*
 }
 
+bux() {
+  sux dotfiles $HOME/code/dotfiles
+  sux jay $HOME/code/jay
+  sux jonallured.com $HOME/code/jonallured.com
+  sux mli $HOME/code/mli
+  sux monolithium $HOME/code/monolithium
+  sux shrt $HOME/code/shrt
+
+  [ -n "$TMUX" ] && echo "ERROR: Already in tmux session, skipping attach." && return 1
+  tmux attach-session -t dotfiles
+}
+
 mux() {
-  if [ -n "$TMUX" ]; then
-    echo "ERROR: You're already in a tmux session. Nesting tmux sessions is a bad idea."
+  local session_name=$(basename $PWD)
+  local start_directory=$PWD
+  sux $session_name $start_directory
+
+  [ -n "$TMUX" ] && echo "ERROR: Already in tmux session, skipping attach." && return 1
+  tmux attach-session -t $session_name
+}
+
+sux() {
+  local session_name=${1//./-}
+  local start_directory=$2
+
+  if ! tmux has-session -t $session_name &>/dev/null; then
+    tmux new-session -d -s $session_name -c $start_directory
+
+    local config_file=$DOTHOME/tmux/$session_name.mux
+    [ -f $config_file ] || config_file=$DOTHOME/tmux/default.mux
+    tmux set-environment -t $session_name mux_name $session_name
+    tmux source-file $config_file
   fi
-
-  name="$(basename $PWD | sed -e 's/\./-/g')"
-
-  if ! $(tmux has-session -t $name &>/dev/null); then
-    tmux new-session -d -s $name
-
-    conf=$DOTHOME/tmux/$name.mux
-    if [ -f $conf ]; then
-      tmux source-file $conf
-    else
-      tmux source-file $DOTHOME/tmux/default.mux
-    fi
-  fi
-
-  tmux attach-session -t $name
 }
 
 pathlist() {

--- a/rcm/zsh/functions
+++ b/rcm/zsh/functions
@@ -46,6 +46,10 @@ mux() {
   tmux attach-session -t $name
 }
 
+pathlist() {
+  echo $PATH | tr ":" "\n" | nl
+}
+
 replace() {
   target="$1"
   shift

--- a/rcm/zsh/path
+++ b/rcm/zsh/path
@@ -6,6 +6,3 @@ export PATH=$PATH:$HOME/code/dotfiles/bin
 
 # remove duplicates
 typeset -aU path
-
-# for troubleshooting:
-# echo $PATH | tr ":" "\n" | nl

--- a/tmux/default.mux
+++ b/tmux/default.mux
@@ -1,10 +1,9 @@
 # vim: ft=tmux
 
-rename-window -t $name:0 code
-split-window -h -t $name:0
-select-layout -t $name:0 main-vertical
-send-keys -t $name:0 'vim .' Enter
+rename-window -t $mux_name:0 code
+split-window -h -c "#{pane_current_path}" -t $mux_name:0
+send-keys -t $mux_name:0 'vim .' Enter
 
-new-window -a -d -n server -t $name
+new-window -a -d -n server -c "#{pane_current_path}" -t $mux_name:0
 
-select-window -t $name:0
+select-window -t $mux_name:0

--- a/tmux/lab_notebook.mux
+++ b/tmux/lab_notebook.mux
@@ -1,19 +1,17 @@
 # vim: ft=tmux
 
 # split the code window and start vim
-rename-window -t $name:0 code
-split-window -h -t $name:0
-select-layout -t $name:0 main-vertical
-send-keys -t $name:0 'vim .' Enter
+rename-window -t $mux_name:0 code
+split-window -h -t $mux_name:0
+send-keys -t $mux_name:0 'vim .' Enter
 
 # create server window and start services
-new-window -a -d -n servers -t $name
-split-window -h -t $name:1
-split-window -h -t $name:1
-select-layout -t $name:1 even-horizontal
-send-keys -t $name:1.0 './bin/static_server' Enter
-send-keys -t $name:1.1 './bin/build_site' Enter
-send-keys -t $name:1.2 './bin/watch_notes' Enter
+new-window -a -d -n servers -t $mux_name
+split-window -h -t $mux_name:1
+split-window -h -t $mux_name:1
+send-keys -t $mux_name:1.0 './bin/static_server' Enter
+send-keys -t $mux_name:1.1 './bin/build_site' Enter
+send-keys -t $mux_name:1.2 './bin/watch_notes' Enter
 
 # go back to code window
-select-window -t $name:0
+select-window -t $mux_name:0


### PR DESCRIPTION
This PR rebuilds the helpers I use to create and attach to tmux sessions. I've extracted the work of creating sessions and then sourcing config into `sux` which `mux` now uses. Then I made `bux` which also uses `sux` but knows the list of my most often used projects so they all get created in one go. The idea is that I'll use `bux` after a reboot to start my standard tmux sessions and then I can use `mux` to either attach like I usually do or just for ad-hoc tmux sessions. I wouldn't expect I'll ever use `sux` directly.

While doing this work I bumped into a few odds and ends that I also wanted to fix so there's a few more things in here. I'll note that I finally noticed that I was lacking `local` in my shell functions so was leaking them out when they are called. I also keep forgetting which tmux border color means active so I'm gonna try green meaning active.