### PR TITLE
Improve branch name transform

### DIFF
--- a/bin/git-better-branch
+++ b/bin/git-better-branch
@@ -10,6 +10,7 @@ git rev-parse --is-inside-work-tree > /dev/null
 current_branch=$(git branch --show-current)
 fallback_name=temp-$(date +%s)
 branch_name=${1:-$fallback_name}
+branch_name=$(echo "$branch_name" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
 
 if ! git show-ref refs/heads/$branch_name --quiet --verify; then
   git branch $branch_name


### PR DESCRIPTION
This is better because now I can type in a phrase as a branch name and it'll be converted into a slugified branch name.