### PR TITLE
Don't ignore asdf config anymore

### DIFF
--- a/rcm/global_ignore
+++ b/rcm/global_ignore
@@ -3,5 +3,4 @@
 .DS_Store
 .netrwhist
 .sw?
-.tool-versions
 tags


### PR DESCRIPTION
I think I used to ignore this because I was using asdf but many of the projects I worked on did not. That's just not the case anymore - all I really work on with my laptop are my projects where asdf is standard.